### PR TITLE
Update stats.py line 19 and 20 led to oled

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -16,8 +16,8 @@ import atexit
 import signal
 
 def exit_handler():
-    led.fill(0)
-    led.show()
+    oled.fill(0)
+    oled.show()
 
 def kill_handler(*args):
     oled.fill(0)


### PR DESCRIPTION
to fix "name 'led' is not defined" appearing in logs #8 

Traceback (most recent call last):
File "/opt/stats/stats.py", line 19, in exit_handler
led.fill(0)